### PR TITLE
Add "proxy_set_header" for correct linking of pagination

### DIFF
--- a/docker/dev/nginx/default.conf
+++ b/docker/dev/nginx/default.conf
@@ -33,6 +33,7 @@ server {
     # Proxy all API requests
     location ~ ^/(api|storage)/ {
         proxy_pass http://nginx:81;
+        proxy_set_header Host $http_host;
     }
 }
 


### PR DESCRIPTION
Without proxy_set_header:
http://nginx:81/api/

With proxy_set_header:
http://localhost:8080/api/